### PR TITLE
🐛  Fix: 실시간 유저수 받아오지 못하는 오류수정

### DIFF
--- a/src/app/news/detail/[id]/page.js
+++ b/src/app/news/detail/[id]/page.js
@@ -108,13 +108,22 @@ const NewsDetailPage = () => {
     const socket = new SockJS(SOCKET_CONFIG.ENDPOINT);
     const client = Stomp.over(socket);
 
-    client.connect({type: SOCKET_CONNECTION_TYPE.PUBLIC}, () => {
-      // 인원 수 토픽 구독
-      client.subscribe(`/topic/chat.${params.id}.count`, ({ body }) => {
-        const { count } = JSON.parse(body);
-        setUserCount(count);
-      });
-    }, console.error);
+    client.connect(
+      {type: SOCKET_CONNECTION_TYPE.PUBLIC}, 
+      () => {
+        // 인원 수 토픽 구독
+        client.subscribe(`/topic/chat.${params.id}.count`, ({ body }) => {
+          const { count } = JSON.parse(body);
+          setUserCount(count);
+        });
+        // 채팅 인원 수 초기화
+        client.send(
+          `/app/chat.initCount.${params.id}`,
+          {},
+          ""
+        );
+      }, console.error
+    );
 
     socketRef.current = client;
 


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)
- [ ] Feat: 새로운 기능 추가
- [x] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결


## ✨ 변경 사항
- 백엔드에 채팅방 이용중인 유저수를 명시적으로 요청하도록 변경


## 🔍 리뷰어에게
```JavaScript
client.subscribe(`/topic/chat.${params.id}.count`, ({ body }) => {
          const { count } = JSON.parse(body);
          setUserCount(count);
        });
```
subscribe 함수의 동작이 이해가 헷갈릴 수 있습니다.
- subscribe 함수의 첫번째 인자는, 구독할 엔드포인트 주소입니다.
- subscribe 함수의 두번째 인자는, 구독한 채널에서 메시지를 수신하였을때 호출할 callback 함수 입니다.  

구독 직후에 send 를 통해 유저수를 요청하면, 두번째 인자의 callback 함수가 호출되어 유저수가 설정되는 방식입니다.


## ✅ PR 체크리스트
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.


## 🔗 관련 이슈
- closed #57 