### PR TITLE
Fix/#70 뉴스 목록 표시 오류 수정

### DIFF
--- a/src/app/dashboard/page.js
+++ b/src/app/dashboard/page.js
@@ -5,15 +5,9 @@ import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import { getScrapList } from '@/app/api/dashboard/scrapListApi';
 import HighlightedText from '@/components/HighlightedText';
+import { removeImageSize } from '@/lib/utils';
 
 const ITEMS_PER_PAGE = 6;
-
-// 이미지 URL에서 사이즈 정보 제거하는 함수
-const removeImageSize = (url) => {
-  if (!url) return url;
-  // /i/숫자/숫자/숫자 패턴을 찾아서 제거
-  return url.replace(/\/i\/\d+\/\d+\/\d+/, '');
-};
 
 export default function DashboardPage() {
   const [scraps, setScraps] = useState([]);

--- a/src/app/news/category/[categoryId]/page.js
+++ b/src/app/news/category/[categoryId]/page.js
@@ -74,7 +74,8 @@ export default function CategoryNewsPage() {
 
       setCarouselNews(carouselGroups);
     } catch (err) {
-      setError(err.message);
+      //setError(err.message);
+      console.error('Carousel news fetch error:', err);
     } finally {
       setCarouselLoading(false);
     }
@@ -141,7 +142,9 @@ export default function CategoryNewsPage() {
           </div>
         ) : (
           <>
-            <hr className="my-8 border-gray-500" />
+            {carouselNews && carouselNews.length > 0 && (
+              <hr className="my-8 border-gray-500" />
+            )}
             <h2 className="text-2xl font-bold mb-4 text-gray-900 flex items-center gap-1">
               <span className="text-blue-500 text-3xl"># </span>최신뉴스
             </h2>

--- a/src/app/news/detail/[id]/page.js
+++ b/src/app/news/detail/[id]/page.js
@@ -15,14 +15,7 @@ import SockJS from 'sockjs-client';
 import { SOCKET_CONFIG, SOCKET_CONNECTION_TYPE } from '@/constants/socketConstants';
 import SelectableText from '@/components/SelectableText';
 import HighlightedText from '@/components/HighlightedText';
-
-
-// 이미지 URL에서 사이즈 정보 제거하는 함수
-const removeImageSize = (url) => {
-  if (!url) return url;
-  // /i/숫자/숫자/숫자 패턴을 찾아서 제거
-  return url.replace(/\/i\/\d+\/\d+\/\d+/, '');
-};
+import { removeImageSize } from '@/lib/utils';
 
 const NewsDetailPage = () => {
   const params = useParams();

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -70,7 +70,8 @@ export default function HomePage() {
       console.log(carouselGroups);
       setCarouselNews(carouselGroups);
     } catch (err) {
-      setError(err.message);
+      //setError(err.message);
+      console.error('Carousel news fetch error:', err);
     } finally {
       setCarouselLoading(false);
     }
@@ -136,7 +137,9 @@ export default function HomePage() {
           </div>
         ) : (
           <>
-            <hr className="my-8 border-gray-500" />
+            {carouselNews && carouselNews.length > 0 && (
+              <hr className="my-8 border-gray-500" />
+            )}
             <h2 className="text-2xl font-bold mb-4 text-gray-900 flex items-center gap-1">
               <span className="text-blue-500 text-3xl"># </span>최신뉴스
             </h2>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -114,7 +114,7 @@ const Header = () => {
 
           {/* 하위 카테고리 섹션 */}
           {showSubCategories && (
-            <div className="py-2 bg-gray-50">
+            <div className="p-2 bg-gray-50">
               <div className="flex gap-6 overflow-x-auto">
                 {CATEGORY_LIST.filter(category => category.id !== 'all').map(category => (
                   <button

--- a/src/components/news/NewsCarousel.js
+++ b/src/components/news/NewsCarousel.js
@@ -67,7 +67,7 @@ export default function NewsCarousel({ carouselGroups = [], loading = false }) {
         {carouselGroups.map((group, index) => (
           <div key={index} className="flex h-full min-w-full flex-col md:flex-row">
             {/* 메인 뉴스 */}
-            <div className={`w-full p-4 ${group.relatedNews && group.relatedNews.length > 0 ? 'md:w-1/2' : 'md:w-full'}`}>
+            <div className="w-full md:w-1/2 p-4">
               <h2 className="text-2xl font-bold mb-4 text-gray-900 flex items-center gap-1">
                 <span className="text-blue-500 text-3xl"># </span>
                 {carouselGroups.length === 2 ? (
@@ -108,13 +108,13 @@ export default function NewsCarousel({ carouselGroups = [], loading = false }) {
             </div>
 
             {/* 관련 뉴스 */}
-            {group.relatedNews && group.relatedNews.length > 0 && (
-              <div className="w-full md:w-1/2 p-4">
-                <h2 className="text-2xl font-bold mb-4 text-gray-900 flex items-center gap-1">
-                  <span className="text-blue-500 text-3xl"># </span>연관뉴스
-                </h2>
-                <div className="flex flex-col gap-3 h-auto md:h-[calc(100%-3rem)]">
-                  {group.relatedNews.map((news) => (
+            <div className="w-full md:w-1/2 p-4">
+              <h2 className="text-2xl font-bold mb-4 text-gray-900 flex items-center gap-1">
+                <span className="text-blue-500 text-3xl"># </span>연관뉴스
+              </h2>
+              <div className="flex flex-col gap-3 h-auto md:h-[calc(100%-3rem)]">
+                {group.relatedNews && group.relatedNews.length > 0 ? (
+                  group.relatedNews.map((news) => (
                     <Link key={news.newsId} href={`/news/detail/${news.newsId}`} className="block h-[120px] md:flex-1">
                       <div className={`flex gap-4 bg-gray-50 rounded-lg overflow-hidden hover:ring-2 hover:ring-[#0E74F9] transition-all h-full ${!news.imageUrl ? 'p-4' : ''}`}>
                         {news.imageUrl && (
@@ -133,10 +133,14 @@ export default function NewsCarousel({ carouselGroups = [], loading = false }) {
                         </div>
                       </div>
                     </Link>
-                  ))}
-                </div>
+                  ))
+                ) : (
+                  <div className="h-full bg-gray-50 rounded-lg p-4 flex flex-col justify-center items-center">
+                    <p className="text-gray-500 text-center">표시할 연관뉴스가 없습니다</p>
+                  </div>
+                )}
               </div>
-            )}
+            </div>
           </div>
         ))}
       </div>

--- a/src/components/news/NewsCarousel.js
+++ b/src/components/news/NewsCarousel.js
@@ -51,9 +51,6 @@ export default function NewsCarousel({ carouselGroups = [], loading = false }) {
 
   if (carouselGroups.length === 0) {
     return (
-      // <div className="relative w-full h-[500px] bg-white mb-8 flex items-center justify-center">
-      //   <p className="text-gray-600">표시할 뉴스가 없습니다.</p>
-      // </div>
       <></>
     );
   }

--- a/src/components/news/NewsCarousel.js
+++ b/src/components/news/NewsCarousel.js
@@ -1,13 +1,6 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { truncateText } from '@/lib/utils';
-
-// 이미지 URL에서 사이즈 정보 제거하는 함수
-const removeImageSize = (url) => {
-  if (!url) return url;
-  // /i/숫자/숫자/숫자 패턴을 찾아서 제거
-  return url.replace(/\/i\/\d+\/\d+\/\d+/, '');
-};
+import { truncateText, removeImageSize } from '@/lib/utils';
 
 export default function NewsCarousel({ carouselGroups = [], loading = false }) {
   const [currentSlide, setCurrentSlide] = useState(0);
@@ -58,9 +51,10 @@ export default function NewsCarousel({ carouselGroups = [], loading = false }) {
 
   if (carouselGroups.length === 0) {
     return (
-      <div className="relative w-full h-[500px] bg-white mb-8 flex items-center justify-center">
-        <p className="text-gray-600">표시할 뉴스가 없습니다.</p>
-      </div>
+      // <div className="relative w-full h-[500px] bg-white mb-8 flex items-center justify-center">
+      //   <p className="text-gray-600">표시할 뉴스가 없습니다.</p>
+      // </div>
+      <></>
     );
   }
 
@@ -73,7 +67,7 @@ export default function NewsCarousel({ carouselGroups = [], loading = false }) {
         {carouselGroups.map((group, index) => (
           <div key={index} className="flex h-full min-w-full flex-col md:flex-row">
             {/* 메인 뉴스 */}
-            <div className="w-full md:w-1/2 p-4">
+            <div className={`w-full p-4 ${group.relatedNews && group.relatedNews.length > 0 ? 'md:w-1/2' : 'md:w-full'}`}>
               <h2 className="text-2xl font-bold mb-4 text-gray-900 flex items-center gap-1">
                 <span className="text-blue-500 text-3xl"># </span>
                 {carouselGroups.length === 2 ? (
@@ -114,33 +108,35 @@ export default function NewsCarousel({ carouselGroups = [], loading = false }) {
             </div>
 
             {/* 관련 뉴스 */}
-            <div className="w-full md:w-1/2 p-4">
-              <h2 className="text-2xl font-bold mb-4 text-gray-900 flex items-center gap-1">
-                <span className="text-blue-500 text-3xl"># </span>연관뉴스
-              </h2>
-              <div className="flex flex-col gap-3 h-auto md:h-[calc(100%-3rem)]">
-                {group.relatedNews.map((news) => (
-                  <Link key={news.newsId} href={`/news/detail/${news.newsId}`} className="block h-[120px] md:flex-1">
-                    <div className={`flex gap-4 bg-gray-50 rounded-lg overflow-hidden hover:ring-2 hover:ring-[#0E74F9] transition-all h-full ${!news.imageUrl ? 'p-4' : ''}`}>
-                      {news.imageUrl && (
-                        <div className="relative w-1/3">
-                          <img
-                            src={removeImageSize(news.imageUrl)}
-                            alt={news.title}
-                            className="w-auto h-auto object-cover absolute inset-0"
-                          />
+            {group.relatedNews && group.relatedNews.length > 0 && (
+              <div className="w-full md:w-1/2 p-4">
+                <h2 className="text-2xl font-bold mb-4 text-gray-900 flex items-center gap-1">
+                  <span className="text-blue-500 text-3xl"># </span>연관뉴스
+                </h2>
+                <div className="flex flex-col gap-3 h-auto md:h-[calc(100%-3rem)]">
+                  {group.relatedNews.map((news) => (
+                    <Link key={news.newsId} href={`/news/detail/${news.newsId}`} className="block h-[120px] md:flex-1">
+                      <div className={`flex gap-4 bg-gray-50 rounded-lg overflow-hidden hover:ring-2 hover:ring-[#0E74F9] transition-all h-full ${!news.imageUrl ? 'p-4' : ''}`}>
+                        {news.imageUrl && (
+                          <div className="relative w-1/3">
+                            <img
+                              src={removeImageSize(news.imageUrl)}
+                              alt={news.title}
+                              className="w-auto h-auto object-cover absolute inset-0"
+                            />
+                          </div>
+                        )}
+                        <div className={`${news.imageUrl ? 'w-2/3 p-2' : 'w-full'} flex flex-col justify-center`}>
+                          <h3 className="text-sm md:text-base font-bold mb-1 md:mb-2 text-gray-900 line-clamp-2 hover:text-blue-600 transition-colors">{news.title}</h3>
+                          <p className="text-xs text-gray-600 line-clamp-2">{truncateText(JSON.parse(news.content).join(''), 80)}</p>
+                          <p className="text-xs text-gray-500 mt-1">{news.date}</p>
                         </div>
-                      )}
-                      <div className={`${news.imageUrl ? 'w-2/3 p-2' : 'w-full'} flex flex-col justify-center`}>
-                        <h3 className="text-sm md:text-base font-bold mb-1 md:mb-2 text-gray-900 line-clamp-2 hover:text-blue-600 transition-colors">{news.title}</h3>
-                        <p className="text-xs text-gray-600 line-clamp-2">{truncateText(JSON.parse(news.content).join(''), 80)}</p>
-                        <p className="text-xs text-gray-500 mt-1">{news.date}</p>
                       </div>
-                    </div>
-                  </Link>
-                ))}
+                    </Link>
+                  ))}
+                </div>
               </div>
-            </div>
+            )}
           </div>
         ))}
       </div>

--- a/src/components/news/NewsList.js
+++ b/src/components/news/NewsList.js
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { truncateText } from '@/lib/utils';
+import { truncateText, removeImageSize } from '@/lib/utils';
 import parse from 'html-react-parser';
 
 export default function NewsList({ news, hasNext, onLoadMore, isLoading }) {
@@ -17,7 +17,7 @@ export default function NewsList({ news, hasNext, onLoadMore, isLoading }) {
             {item.imageUrl && (
               <div className="w-full md:w-[200px] md:flex-shrink-0">
                 <img 
-                  src={item.imageUrl} 
+                  src={removeImageSize(item.imageUrl)} 
                   alt={item.title}
                   className="w-full h-[150px] object-cover rounded-lg"
                 />

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -30,4 +30,15 @@ export const truncateText = (text, maxLength = 150) => {
   if (!text) return '';
   if (text.length <= maxLength) return text;
   return text.substring(0, maxLength) + '...';
+};
+
+/**
+ * 이미지 URL에서 사이즈 정보를 제거합니다.
+ * @param {string} url - 처리할 이미지 URL
+ * @returns {string} 사이즈 정보가 제거된 URL
+ */
+export const removeImageSize = (url) => {
+  if (!url) return url;
+  // /i/숫자/숫자/숫자 패턴을 찾아서 제거
+  return url.replace(/\/i\/\d+\/\d+\/\d+/, '');
 }; 


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)
- [ ] Feat: 새로운 기능 추가
- [x] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [x] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결


## ✨ 변경 사항
- 인기뉴스가 없는 경우, 최신 뉴스를 받아왔음에도 불구하고 출력하지 못하는 오류가 있었습니다. 출력 조건 변경을 통해 인기뉴스가 없어도 최신뉴스는 표시할 수 있도록 하였습니다.
- 인기 뉴스가 없는 경우 해당 영역을 표시하지 않도록 변경하였습니다.
- 특정 언론사 뉴스 이미지 해상도가 낮게 제공되고 있어, 뉴스 상세페이지에서는 이를 url을 바꾸어 해결하고 있었습니다.   
뉴스 목록에서도 해당 함수를 사용하기 위하여 공통 함수로 선언, import 하여 사용하도록 리팩토링 하였습니다.


## ✅ PR 체크리스트
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.


## 🔗 관련 이슈
closed #70 